### PR TITLE
✨ feat: 약속 도메인 엔티티 및 VO 구현

### DIFF
--- a/src/main/java/org/noostak/server/appointment/domain/Appointment.java
+++ b/src/main/java/org/noostak/server/appointment/domain/Appointment.java
@@ -3,6 +3,8 @@ package org.noostak.server.appointment.domain;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.noostak.server.appointment.domain.vo.AppointmentName;
+import org.noostak.server.appointment.domain.vo.AppointmentStatus;
 import org.noostak.server.global.entity.BaseTimeEntity;
 import org.noostak.server.member.domain.Member;
 import org.noostak.server.group.domain.Group;

--- a/src/main/java/org/noostak/server/appointment/domain/AppointmentMember.java
+++ b/src/main/java/org/noostak/server/appointment/domain/AppointmentMember.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.noostak.server.appointment.domain.vo.AppointmentAvailability;
 import org.noostak.server.global.entity.BaseTimeEntity;
 import org.noostak.server.member.domain.Member;
 

--- a/src/main/java/org/noostak/server/appointment/domain/AppointmentMember.java
+++ b/src/main/java/org/noostak/server/appointment/domain/AppointmentMember.java
@@ -10,12 +10,21 @@ import org.noostak.server.member.domain.Member;
 
 import java.time.LocalDateTime;
 
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.noostak.server.appointment.domain.vo.AppointmentAvailability;
+import org.noostak.server.global.entity.BaseTimeEntity;
+import org.noostak.server.member.domain.Member;
+
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AppointmentMember extends BaseTimeEntity {
 
-    // TODO : 역할을 부여할 enum? host, member, admin 등등?
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long appointmentMemberId;

--- a/src/main/java/org/noostak/server/appointment/domain/Option.java
+++ b/src/main/java/org/noostak/server/appointment/domain/Option.java
@@ -1,0 +1,50 @@
+package org.noostak.server.appointment.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Option {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long optionId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "appointment_id")
+    private Appointment appointment;
+
+    private LocalDateTime date;
+
+    private LocalDateTime startTime;
+
+    private LocalDateTime endTime;
+
+    public void initAppointment(Appointment appointment) {
+        validateAppointment(appointment);
+        this.appointment = appointment;
+    }
+
+    public void clearAppointment() {
+        validateClearableAppointment();
+        this.appointment = null;
+    }
+
+    private void validateAppointment(Appointment appointment) {
+        if (this.appointment != null) {
+            throw new IllegalStateException("[ERROR] 연관된 Appointment가 존재합니다.");
+        }
+    }
+
+    private void validateClearableAppointment() {
+        if (this.appointment == null) {
+            throw new IllegalStateException("[ERROR] 연관된 Appointment가 존재하지 않습니다.");
+        }
+    }
+
+}

--- a/src/main/java/org/noostak/server/appointment/domain/vo/AppointMemberCount.java
+++ b/src/main/java/org/noostak/server/appointment/domain/vo/AppointMemberCount.java
@@ -1,0 +1,64 @@
+package org.noostak.server.appointment.domain.vo;
+
+import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
+
+@Embeddable
+@EqualsAndHashCode
+public class AppointMemberCount {
+
+    private static final Long MAX_MEMBERS = 50L;
+
+    private final Long count;
+
+    protected AppointMemberCount() {
+        this.count = 0L;
+    }
+
+    private AppointMemberCount(Long count) {
+        validate(count);
+        this.count = count;
+    }
+
+    public static AppointMemberCount from(Long count) {
+        return new AppointMemberCount(count);
+    }
+
+    public Long value() {
+        return count;
+    }
+
+    public AppointMemberCount increase() {
+        Long updatedCount = this.count + 1;
+        validate(updatedCount);
+        return new AppointMemberCount(updatedCount);
+    }
+
+    public AppointMemberCount decrease() {
+        Long updatedCount = this.count - 1;
+        validate(updatedCount);
+        return new AppointMemberCount(updatedCount);
+    }
+
+    private void validate(Long count) {
+        validateNonNegative(count);
+        validateMaxLimit(count);
+    }
+
+    private void validateNonNegative(Long count) {
+        if (count < 0) {
+            throw new IllegalArgumentException("[ERROR] 약속 멤버 수는 음수가 될 수 없습니다.");
+        }
+    }
+
+    private void validateMaxLimit(Long count) {
+        if (count > MAX_MEMBERS) {
+            throw new IllegalArgumentException("[ERROR] 약속 멤버 수는 최대 " + MAX_MEMBERS + "명을 초과할 수 없습니다.");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(count);
+    }
+}

--- a/src/main/java/org/noostak/server/appointment/domain/vo/AppointmentAvailability.java
+++ b/src/main/java/org/noostak/server/appointment/domain/vo/AppointmentAvailability.java
@@ -1,4 +1,4 @@
-package org.noostak.server.appointment.domain;
+package org.noostak.server.appointment.domain.vo;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/org/noostak/server/appointment/domain/vo/AppointmentCategory.java
+++ b/src/main/java/org/noostak/server/appointment/domain/vo/AppointmentCategory.java
@@ -1,0 +1,15 @@
+package org.noostak.server.appointment.domain.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AppointmentCategory {
+    IMPORTANT("중요"),
+    SCHEDULE("일정"),
+    HOBBY("취미"),
+    OTHER("기타");
+
+    private final String message;
+}

--- a/src/main/java/org/noostak/server/appointment/domain/vo/AppointmentName.java
+++ b/src/main/java/org/noostak/server/appointment/domain/vo/AppointmentName.java
@@ -3,6 +3,9 @@ package org.noostak.server.appointment.domain.vo;
 import jakarta.persistence.Embeddable;
 import lombok.EqualsAndHashCode;
 
+import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
+
 @Embeddable
 @EqualsAndHashCode
 public class AppointmentName {
@@ -13,9 +16,13 @@ public class AppointmentName {
         this.appointmentName = null;
     }
 
-    public AppointmentName(String appointmentName) {
+    private AppointmentName(String appointmentName) {
         validateAppointmentName(appointmentName);
         this.appointmentName = appointmentName;
+    }
+
+    public static AppointmentName from(String appointmentName) {
+        return new AppointmentName(appointmentName);
     }
 
     public String value() {
@@ -25,7 +32,6 @@ public class AppointmentName {
     private void validateAppointmentName(String appointmentName) {
         validateEmpty(appointmentName);
         validateLength(appointmentName);
-        validateSpecialLetter(appointmentName);
     }
 
     private void validateEmpty(String appointmentName) {
@@ -37,12 +43,6 @@ public class AppointmentName {
     private void validateLength(String appointmentName) {
         if (appointmentName.length() > 30) {
             throw new IllegalArgumentException("[ERROR] 약속 이름의 길이는 30글자를 넘을 수 없습니다.");
-        }
-    }
-
-    private void validateSpecialLetter(String appointmentName) {
-        if (!appointmentName.chars().allMatch(Character::isAlphabetic)) {
-            throw new IllegalArgumentException("[ERROR] 약속 이름은 알파벳 혹은 한글로만 구성이 가능합니다.");
         }
     }
 

--- a/src/main/java/org/noostak/server/appointment/domain/vo/AppointmentName.java
+++ b/src/main/java/org/noostak/server/appointment/domain/vo/AppointmentName.java
@@ -1,4 +1,4 @@
-package org.noostak.server.appointment.domain;
+package org.noostak.server.appointment.domain.vo;
 
 import jakarta.persistence.Embeddable;
 import lombok.EqualsAndHashCode;

--- a/src/main/java/org/noostak/server/appointment/domain/vo/AppointmentStatus.java
+++ b/src/main/java/org/noostak/server/appointment/domain/vo/AppointmentStatus.java
@@ -1,4 +1,4 @@
-package org.noostak.server.appointment.domain;
+package org.noostak.server.appointment.domain.vo;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/org/noostak/server/appointment/domain/vo/AppointmentStatus.java
+++ b/src/main/java/org/noostak/server/appointment/domain/vo/AppointmentStatus.java
@@ -6,10 +6,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum AppointmentStatus {
-    IMPORTANT("중요"),
-    SCHEDULE("일정"),
-    HOBBY("취미"),
-    OTHER("기타");
+    CONFIRMED("확정"),
+    PROGRESS("진행중");
 
     private final String message;
 }

--- a/src/test/java/org/noostak/server/appointment/domain/OptionTest.java
+++ b/src/test/java/org/noostak/server/appointment/domain/OptionTest.java
@@ -1,0 +1,79 @@
+package org.noostak.server.appointment.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mock;
+
+class OptionTest {
+
+    @Nested
+    @DisplayName("성공 케이스")
+    class SuccessCases {
+
+        @Test
+        @DisplayName("연관 Appointment 초기화 성공")
+        void shouldInitAppointmentSuccessfully() {
+            // Given
+            Option option = new Option();
+            Appointment appointment = mock(Appointment.class);
+
+            // When
+            option.initAppointment(appointment);
+
+            // Then
+            assertThat(option.getAppointment()).isEqualTo(appointment);
+
+        }
+
+        @Test
+        @DisplayName("연관 Appointment 해제 성공")
+        void shouldClearAppointmentSuccessfully() {
+            // Given
+            Option option = new Option();
+            Appointment appointment = mock(Appointment.class);
+            option.initAppointment(appointment);
+
+            // When
+            option.clearAppointment();
+
+            // Then
+            assertThat(option.getAppointment()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 케이스")
+    class FailureCases {
+
+        @Test
+        @DisplayName("이미 연관된 Appointment가 있는 경우 초기화 시도 실패")
+        void shouldThrowExceptionWhenAlreadyLinkedToAppointment() {
+            // Given
+            Option option = new Option();
+            Appointment appointment1 = mock(Appointment.class);
+            Appointment appointment2 = mock(Appointment.class);
+            option.initAppointment(appointment1);
+
+            // When & Then
+            assertThatThrownBy(() -> option.initAppointment(appointment2))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("[ERROR] 연관된 Appointment가 존재합니다.");
+        }
+
+        @Test
+        @DisplayName("연관된 Appointment가 없는 경우 해제 시도 실패")
+        void shouldThrowExceptionWhenClearingWithoutLinkedAppointment() {
+            // Given
+            Option option = new Option();
+
+            // When & Then
+            assertThatThrownBy(option::clearAppointment)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("[ERROR] 연관된 Appointment가 존재하지 않습니다.");
+        }
+    }
+}

--- a/src/test/java/org/noostak/server/appointment/domain/vo/AppointMemberCountTest.java
+++ b/src/test/java/org/noostak/server/appointment/domain/vo/AppointMemberCountTest.java
@@ -1,0 +1,96 @@
+package org.noostak.server.appointment.domain.vo;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AppointMemberCountTest {
+
+    @Nested
+    @DisplayName("성공 케이스")
+    class SuccessCases {
+
+        @Test
+        @DisplayName("초기 멤버 수가 0인 객체 생성")
+        void shouldCreateWithZeroInitialValue() {
+            // Given
+            Long initialCount = 0L;
+
+            // When
+            AppointMemberCount count = AppointMemberCount.from(initialCount);
+
+            // Then
+            assertThat(count.value()).isEqualTo(initialCount);
+        }
+
+        @Test
+        @DisplayName("멤버 수 증가")
+        void shouldIncreaseMemberCount() {
+            // Given
+            AppointMemberCount count = AppointMemberCount.from(10L);
+
+            // When
+            AppointMemberCount increasedCount = count.increase();
+
+            // Then
+            assertThat(increasedCount.value()).isEqualTo(11L);
+        }
+
+        @Test
+        @DisplayName("멤버 수 감소")
+        void shouldDecreaseMemberCount() {
+            // Given
+            AppointMemberCount count = AppointMemberCount.from(10L);
+
+            // When
+            AppointMemberCount decreasedCount = count.decrease();
+
+            // Then
+            assertThat(decreasedCount.value()).isEqualTo(9L);
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 케이스")
+    class FailureCases {
+
+        @Test
+        @DisplayName("멤버 수가 음수가 될 경우 예외 발생")
+        void shouldThrowExceptionWhenCountIsNegative() {
+            // Given
+            AppointMemberCount count = AppointMemberCount.from(0L);
+
+            // When & Then
+            assertThatThrownBy(count::decrease)
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("[ERROR] 약속 멤버 수는 음수가 될 수 없습니다.");
+        }
+
+        @Test
+        @DisplayName("멤버 수가 최대값을 초과할 경우 예외 발생")
+        void shouldThrowExceptionWhenCountExceedsMaxLimit() {
+            // Given
+            AppointMemberCount count = AppointMemberCount.from(50L);
+
+            // When & Then
+            assertThatThrownBy(count::increase)
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("[ERROR] 약속 멤버 수는 최대 50명을 초과할 수 없습니다.");
+        }
+
+        @Test
+        @DisplayName("초기값이 음수일 경우 예외 발생")
+        void shouldThrowExceptionWhenInitialValueIsNegative() {
+            // Given
+            Long initialCount = -1L;
+
+            // When & Then
+            assertThatThrownBy(() -> AppointMemberCount.from(initialCount))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("[ERROR] 약속 멤버 수는 음수가 될 수 없습니다.");
+        }
+    }
+}

--- a/src/test/java/org/noostak/server/appointment/domain/vo/AppointmentNameTest.java
+++ b/src/test/java/org/noostak/server/appointment/domain/vo/AppointmentNameTest.java
@@ -1,0 +1,107 @@
+package org.noostak.server.appointment.domain.vo;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AppointmentNameTest {
+
+    @Nested
+    @DisplayName("성공 케이스")
+    class SuccessCases {
+
+        @ParameterizedTest
+        @DisplayName("유효한 약속 이름으로 객체 생성")
+        @CsvSource({
+                "Team Meeting",
+                "한글 약속",
+                "Meeting123",
+                "1234567890",
+                "Lunch 🍴",
+                "🎉 Party",
+                "@Special_Event",
+                "Valid-Name",
+                "Group: Study",
+                "sepecial#!@#!$"
+        })
+        void shouldCreateAppointmentNameSuccessfully(String validName) {
+            // Given
+            String appointmentName = validName;
+
+            // When
+            AppointmentName generatedName = AppointmentName.from(appointmentName);
+
+            // Then
+            assertThat(generatedName.value()).isEqualTo(validName);
+        }
+    }
+
+    @Nested
+    @DisplayName("실패 케이스")
+    class FailureCases {
+
+        @ParameterizedTest
+        @DisplayName("약속 이름이 null인 경우 예외 발생")
+        @NullSource
+        void shouldThrowExceptionForNullName(String nullName) {
+            // Given
+            String appointmentName = nullName;
+
+            // When & Then
+            assertThatThrownBy(() -> AppointmentName.from(appointmentName))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("[ERROR] 약속 이름은 비어 있을 수 없습니다.");
+        }
+
+        @ParameterizedTest
+        @DisplayName("약속 이름이 빈 문자열인 경우 예외 발생")
+        @CsvSource({
+                "''"
+        })
+        void shouldThrowExceptionForEmptyString(String emptyName) {
+            // Given
+            String appointmentName = emptyName;
+
+            // When & Then
+            assertThatThrownBy(() -> AppointmentName.from(appointmentName))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("[ERROR] 약속 이름은 비어 있을 수 없습니다.");
+        }
+
+        @ParameterizedTest
+        @DisplayName("약속 이름이 공백 문자열인 경우 예외 발생")
+        @CsvSource({
+                "'   '"
+        })
+        void shouldThrowExceptionForBlankString(String blankName) {
+            // Given
+            String appointmentName = blankName;
+
+            // When & Then
+            assertThatThrownBy(() -> AppointmentName.from(appointmentName))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("[ERROR] 약속 이름은 비어 있을 수 없습니다.");
+        }
+
+        @ParameterizedTest
+        @DisplayName("약속 이름의 길이가 30자를 초과하는 경우 예외 발생")
+        @CsvSource({
+                "abcdefghijklmnopqrstuvwxyz12345",
+                "1234567890123456789012345678901"
+        })
+        void shouldThrowExceptionForNameExceedingMaxLength(String invalidName) {
+            // Given
+            String appointmentName = invalidName;
+
+            // When & Then
+            assertThatThrownBy(() -> AppointmentName.from(appointmentName))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("[ERROR] 약속 이름의 길이는 30글자를 넘을 수 없습니다.");
+        }
+    }
+}


### PR DESCRIPTION
# 🚀 What’s this PR about?
- **작업 내용 요약:** 약속 도메인에 관련된 엔티티와 VO들을 구현하였습니다.
- **핵심 변경사항:** 구현한 약속 도메인에 대한 테스트 커버리지는 79%입니다.

# 🛠️ What’s been done?
- 주요 변경사항을 상세히 기술합니다:
  - 약속, 약속 멤버, 옵션 엔티티를 구현하였습니다.
  - 약속, 약속 멤버, 옵션 엔티티 관련 `VO`들을 구현하였습니다.
  - 검증이 필요한 로직들은 테스트 코드를 작성하여 검증하였습니다.

# 🎯 Related Issues
- 관련 이슈: #14 

# 🧪 Testing Details
- **테스트 코드 및 결과:**
  - 구현한 코드들의 커버리지는 약속 도메인의 79%를 커버합니다.

# 👀 Checkpoints for Reviewers
- **리뷰 시 확인할 사항:**
  - 전반적으로 이전에 도메인을 구현한 코드들과 유사한 패턴들을 적용하여 구현하였습니다.
  - 테스트 코드를 작성하여 구현 코드에 대한 검증을 수행하였습니다.
  - 이번엔 약속 관련 엔티티가 3개가 있어 연관관계가 올바르게 맺어져있는지 중심으로 검토해주시면 감사하겠습니다.

