### PR TITLE
[refactor] group 및 like 테이블 이름 예약어 충돌 해결

### DIFF
--- a/src/main/java/org/noostak/server/group/domain/Group.java
+++ b/src/main/java/org/noostak/server/group/domain/Group.java
@@ -16,6 +16,7 @@ import java.util.Set;
 @Entity
 @Getter
 @RequiredArgsConstructor
+@Table(name = "groups")
 public class Group extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/org/noostak/server/like/domain/Like.java
+++ b/src/main/java/org/noostak/server/like/domain/Like.java
@@ -12,6 +12,7 @@ import org.noostak.server.appointment.domain.Option;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "likes")
 public class Like extends BaseTimeEntity {
 
     @Id


### PR DESCRIPTION
# 🚀 What’s this PR about?
- **작업 내용 요약:** 그룹과 좋아요 테이블의 이름이 예약어와 충돌하는 문제를 해결했습니다.
- **핵심 변경사항:** `@Table` 애노테이션을 활용하여 테이블 이름을 명시적으로 `groups`와 `likes`로 설정하였습니다.

# 🛠️ What’s been done?
- 그룹 엔티티와 좋아요 엔티티에 각각 `@Table(name = "groups")` 및 `@Table(name = "likes")`를 추가하여 예약어 충돌 문제를 방지했습니다.
- 주요 변경 로직:
  - `Group` 클래스: `@Table(name = "groups")` 추가
  - `Like` 클래스: `@Table(name = "likes")` 추가
- 테스트 및 주요 시나리오:
  - 테이블 생성 시 올바르게 이름이 반영되는지 확인
  - 예약어와 충돌 없이 애플리케이션이 정상 동작하는지 검증

# 👀 Checkpoints for Reviewers
- **리뷰 시 확인할 사항:**
  - `@Table` 애노테이션이 모든 관련 클래스에 올바르게 적용되었는지 확인
  - 변경된 테이블 이름으로 인한 추가적인 영향 범위가 없는지 검토
- **논의할 주제:**
  - 테이블 이름 설정 외 추가적으로 고려해야 할 부분이 있는지
  - 다른 엔티티에서도 비슷한 문제가 발생할 가능성 검토 필요

# 🎯 Related Issues
- #21 