### PR TITLE
[refactor] SuccessCode 및 SuccessResponse 코드 구조 개선

### DIFF
--- a/src/main/java/org/noostak/server/global/success/core/SuccessResponse.java
+++ b/src/main/java/org/noostak/server/global/success/core/SuccessResponse.java
@@ -2,9 +2,10 @@ package org.noostak.server.global.success.core;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import org.noostak.server.global.success.handler.SuccessCode;
+import org.springframework.http.HttpStatus;
 
 public record SuccessResponse<T>(
-        int status,
+        HttpStatus status,
         String message,
         @JsonInclude(JsonInclude.Include.NON_NULL)
         T result

--- a/src/main/java/org/noostak/server/global/success/handler/SuccessCode.java
+++ b/src/main/java/org/noostak/server/global/success/handler/SuccessCode.java
@@ -1,6 +1,8 @@
 package org.noostak.server.global.success.handler;
 
+import org.springframework.http.HttpStatus;
+
 public interface SuccessCode {
-    int getStatus();
+    HttpStatus getStatus();
     String getMessage();
 }

--- a/src/main/java/org/noostak/server/group/common/GroupSuccessCode.java
+++ b/src/main/java/org/noostak/server/group/common/GroupSuccessCode.java
@@ -3,17 +3,17 @@ package org.noostak.server.group.common;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.noostak.server.global.success.handler.SuccessCode;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
 public enum GroupSuccessCode implements SuccessCode {
-    GROUP_CREATED(201, "그룹이 성공적으로 생성되었습니다."),
-    GROUP_UPDATED(200, "그룹 정보가 성공적으로 수정되었습니다."),
-    GROUP_DELETED(200, "그룹이 성공적으로 삭제되었습니다."),
+    GROUP_CREATED(HttpStatus.CREATED, "그룹이 성공적으로 생성되었습니다."),
+    GROUP_UPDATED(HttpStatus.OK, "그룹 정보가 성공적으로 수정되었습니다."),
+    GROUP_DELETED(HttpStatus.OK, "그룹이 성공적으로 삭제되었습니다."),
 
-    SUCCESS_GET_GROUP_LIST(200, "유저의 그룹 목록을 성공적으로 조회했습니다."),
-    ;
+    SUCCESS_GET_GROUP_LIST(HttpStatus.OK, "유저의 그룹 목록을 성공적으로 조회했습니다.");
 
-    private final int status;
+    private final HttpStatus status;
     private final String message;
 }


### PR DESCRIPTION
# 🚀 What’s this PR about?
- **작업 내용 요약:** `SuccessCode`와 `SuccessResponse` 코드 구조를 개선하여 가독성과 확장성을 높이고, 중복 코드를 최소화했습니다.
- **핵심 변경사항:** 상태 코드 타입을 `int`에서 `HttpStatus`로 변경하여 명확성과 일관성을 강화했습니다.

# 🛠️ What’s been done?
- 주요 변경사항:
  - `SuccessCode` 인터페이스에서 상태 코드 타입을 `int`에서 `HttpStatus`로 변경.
  - `SuccessResponse` 클래스에서 상태 코드 필드를 `HttpStatus`로 수정하고 관련 로직을 업데이트.
  - `GroupSuccessCode` enum에서 상태 코드 정의 방식을 `HttpStatus`로 변경하여 의미 명확성을 개선.


# 👀 Checkpoints for Reviewers
- **리뷰 시 확인할 사항:**
  - 상태 코드 변경으로 인한 예상치 못한 영향 여부.
  - 코드 스타일 및 가독성 개선 여부.
  - 변경된 상태 코드와 메시지의 일관성.
- 추가로 논의하고 싶은 주제:
  - 상태 코드 관리 방식에 대한 추가 의견.
  - `HttpStatus` 사용이 전체 프로젝트 구조와 잘 맞는지.

# 🎯 Related Issues
- closes #33