### PR TITLE
[✨feat] S3 이미지 URL 반환 기능

### DIFF
--- a/src/main/java/org/noostak/server/infra/S3Service.java
+++ b/src/main/java/org/noostak/server/infra/S3Service.java
@@ -41,7 +41,7 @@ public class S3Service implements FileStorageService {
 
         s3Client.putObject(request, RequestBody.fromBytes(image.getBytes()));
 
-        return generateFileUrl(key); // S3 URL 반환
+        return generateFileUrl(key);
     }
 
     @Override
@@ -57,12 +57,12 @@ public class S3Service implements FileStorageService {
     }
 
     public ProfileImageUrl uploadProfileImage(MultipartFile file) throws IOException {
-        String url = uploadImage("/profile/", file); // /profile 디렉토리에 저장
+        String url = uploadImage("/profile/", file);
         return ProfileImageUrl.from(url);
     }
 
     public GroupImageUrl uploadGroupImage(MultipartFile file) throws IOException {
-        String url = uploadImage("/group/", file); // /group 디렉토리에 저장
+        String url = uploadImage("/group/", file);
         return GroupImageUrl.from(url);
     }
 

--- a/src/main/java/org/noostak/server/infra/S3Service.java
+++ b/src/main/java/org/noostak/server/infra/S3Service.java
@@ -2,8 +2,10 @@ package org.noostak.server.infra;
 
 import lombok.RequiredArgsConstructor;
 import org.noostak.server.global.config.AwsConfig;
+import org.noostak.server.group.domain.vo.GroupImageUrl;
 import org.noostak.server.infra.error.S3UploadErrorCode;
 import org.noostak.server.infra.error.S3UploadException;
+import org.noostak.server.member.domain.vo.ProfileImageUrl;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -26,27 +28,25 @@ public class S3Service implements FileStorageService {
 
     @Override
     public String uploadImage(String directoryPath, MultipartFile image) throws IOException {
-        final String key = directoryPath + generateImageFileName();
-        final S3Client s3Client = awsConfig.getS3Client();
+        validateFile(image);
 
-        validateExtension(image);
-        validateFileSize(image);
+        String key = directoryPath + generateFileName(image.getOriginalFilename());
+        S3Client s3Client = awsConfig.getS3Client();
 
         PutObjectRequest request = PutObjectRequest.builder()
                 .bucket(awsConfig.getS3BucketName())
                 .key(key)
                 .contentType(image.getContentType())
-                .contentDisposition("inline")
                 .build();
 
-        RequestBody requestBody = RequestBody.fromBytes(image.getBytes());
-        s3Client.putObject(request, requestBody);
-        return key;
+        s3Client.putObject(request, RequestBody.fromBytes(image.getBytes()));
+
+        return generateFileUrl(key); // S3 URL 반환
     }
 
     @Override
     public void deleteImage(String key) throws IOException {
-        final S3Client s3Client = awsConfig.getS3Client();
+        S3Client s3Client = awsConfig.getS3Client();
 
         DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
                 .bucket(awsConfig.getS3BucketName())
@@ -56,19 +56,34 @@ public class S3Service implements FileStorageService {
         s3Client.deleteObject(deleteRequest);
     }
 
-    private String generateImageFileName() {
-        return UUID.randomUUID() + ".jpg";
+    public ProfileImageUrl uploadProfileImage(MultipartFile file) throws IOException {
+        String url = uploadImage("/profile/", file); // /profile 디렉토리에 저장
+        return ProfileImageUrl.from(url);
     }
 
-    private void validateExtension(MultipartFile image) {
-        String contentType = image.getContentType();
-        if (!IMAGE_EXTENSIONS.contains(contentType)) {
+    public GroupImageUrl uploadGroupImage(MultipartFile file) throws IOException {
+        String url = uploadImage("/group/", file); // /group 디렉토리에 저장
+        return GroupImageUrl.from(url);
+    }
+
+    private String generateFileName(String originalFilename) {
+        String extension = originalFilename.substring(originalFilename.lastIndexOf("."));
+        return UUID.randomUUID() + extension;
+    }
+
+    private String generateFileUrl(String key) {
+        return String.format("https://%s.s3.%s.amazonaws.com/%s",
+                awsConfig.getS3BucketName(),
+                awsConfig.getRegion().id(),
+                key);
+    }
+
+    private void validateFile(MultipartFile file) {
+        if (!IMAGE_EXTENSIONS.contains(file.getContentType())) {
             throw new S3UploadException(S3UploadErrorCode.INVALID_EXTENSION);
         }
-    }
 
-    private void validateFileSize(MultipartFile image) {
-        if (image.getSize() > awsConfig.getMaxFileSize()) {
+        if (file.getSize() > awsConfig.getMaxFileSize()) {
             throw new S3UploadException(S3UploadErrorCode.FILE_SIZE_EXCEEDED);
         }
     }

--- a/src/main/java/org/noostak/server/infra/error/S3ErrorCode.java
+++ b/src/main/java/org/noostak/server/infra/error/S3ErrorCode.java
@@ -7,11 +7,12 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
-public enum S3UploadErrorCode implements ErrorCode {
+public enum S3ErrorCode implements ErrorCode {
     INVALID_EXTENSION(HttpStatus.BAD_REQUEST, "이미지 확장자는 jpg, png, webp만 가능합니다."),
-    FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "이미지 사이즈는 5MB를 넘을 수 없습니다.");
+    FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "이미지 사이즈는 5MB를 넘을 수 없습니다."),
+    OBJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "삭제하려는 이미지를 찾을 수 없습니다.");
 
-    public static final String PREFIX = "[S3 UPLOAD ERROR] ";
+    public static final String PREFIX = "[S3 ERROR] ";
 
     private final HttpStatus status;
     private final String rawMessage;

--- a/src/main/java/org/noostak/server/infra/error/S3Exception.java
+++ b/src/main/java/org/noostak/server/infra/error/S3Exception.java
@@ -2,8 +2,8 @@ package org.noostak.server.infra.error;
 
 import org.noostak.server.global.error.core.BaseException;
 
-public class S3UploadException extends BaseException {
-    public S3UploadException(S3UploadErrorCode errorCode) {
+public class S3Exception extends BaseException {
+    public S3Exception(S3ErrorCode errorCode) {
         super(errorCode);
     }
 }

--- a/src/test/java/org/noostak/server/infra/S3ServiceTest.java
+++ b/src/test/java/org/noostak/server/infra/S3ServiceTest.java
@@ -6,17 +6,18 @@ import org.junit.jupiter.api.Test;
 import org.noostak.server.global.config.AwsConfig;
 import org.noostak.server.infra.error.S3UploadErrorCode;
 import org.noostak.server.infra.error.S3UploadException;
+import org.noostak.server.member.domain.vo.ProfileImageUrl;
+import org.noostak.server.group.domain.vo.GroupImageUrl;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.IOException;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 class S3ServiceTest {
@@ -27,89 +28,115 @@ class S3ServiceTest {
     private final S3Service s3Service = new S3Service(awsConfig);
 
     @Nested
-    @DisplayName("이미지 업로드 테스트")
-    class UploadImageTests {
+    @DisplayName("프로필 이미지 업로드 테스트")
+    class UploadProfileImageTests {
+
+        private final String bucketName = "test-bucket";
+        private final String profileDirectory = "profile/";
 
         @Test
         @DisplayName("이미지 업로드 - 성공")
-        void uploadImage_success() throws IOException {
+        void uploadProfileImage_success() throws IOException {
             // Given
-            String directoryPath = "images/";
-            MultipartFile image = new MockMultipartFile(
-                    "image",
-                    "test.jpg",
-                    "image/jpeg",
-                    new byte[]{1, 2, 3, 4}
-            );
-
-            when(awsConfig.getS3Client()).thenReturn(s3Client);
-            when(awsConfig.getS3BucketName()).thenReturn("test-bucket");
-            when(awsConfig.getMaxFileSize()).thenReturn(1024L * 1024 * 2);
+            MultipartFile file = createMockImage("profile.jpg", "image/jpeg", new byte[]{1, 2, 3, 4});
+            setupMockForUpload();
 
             // When
-            String result = s3Service.uploadImage(directoryPath, image);
+            ProfileImageUrl result = s3Service.uploadProfileImage(file);
 
             // Then
-            assertThat(result).startsWith(directoryPath).endsWith(".jpg");
+            assertThat(result.toString())
+                    .startsWith("https://test-bucket.s3.")
+                    .contains(profileDirectory)
+                    .endsWith(".jpg");
             verify(s3Client).putObject(any(PutObjectRequest.class), any(RequestBody.class));
         }
 
-
         @Test
         @DisplayName("이미지 업로드 - 잘못된 확장자")
-        void uploadImage_invalidExtension() {
+        void uploadProfileImage_invalidExtension() {
             // Given
-            String directoryPath = "images/";
-            MultipartFile image = new MockMultipartFile(
-                    "image",
-                    "test.txt",
-                    "text/plain",
-                    new byte[]{1, 2, 3, 4}
-            );
+            MultipartFile file = createMockImage("invalid.txt", "text/plain", new byte[]{1, 2, 3, 4});
 
             // When & Then
-            assertThatThrownBy(() -> s3Service.uploadImage(directoryPath, image))
+            assertThatThrownBy(() -> s3Service.uploadProfileImage(file))
                     .isInstanceOf(S3UploadException.class)
                     .hasMessageContaining(S3UploadErrorCode.INVALID_EXTENSION.getMessage());
         }
 
         @Test
         @DisplayName("이미지 업로드 - 파일 크기 초과")
-        void uploadImage_fileSizeExceedsLimit() {
+        void uploadProfileImage_fileSizeExceedsLimit() {
             // Given
-            String directoryPath = "images/";
-            MultipartFile image = new MockMultipartFile(
-                    "image",
-                    "large.jpg",
-                    "image/jpeg",
-                    new byte[3 * 1024 * 1024]
-            );
+            MultipartFile file = createMockImage("large.jpg", "image/jpeg", new byte[3 * 1024 * 1024]);
             when(awsConfig.getMaxFileSize()).thenReturn(2L * 1024 * 1024);
 
             // When & Then
-            assertThatThrownBy(() -> s3Service.uploadImage(directoryPath, image))
+            assertThatThrownBy(() -> s3Service.uploadProfileImage(file))
                     .isInstanceOf(S3UploadException.class)
                     .hasMessageContaining(S3UploadErrorCode.FILE_SIZE_EXCEEDED.getMessage());
         }
     }
 
     @Nested
-    @DisplayName("이미지 삭제 테스트")
-    class DeleteImageTests {
+    @DisplayName("그룹 이미지 업로드 테스트")
+    class UploadGroupImageTests {
+
+        private final String bucketName = "test-bucket";
+        private final String groupDirectory = "group/";
 
         @Test
-        @DisplayName("이미지 삭제 - 성공")
-        void deleteImage_success() throws IOException {
+        @DisplayName("이미지 업로드 - 성공")
+        void uploadGroupImage_success() throws IOException {
             // Given
-            String key = "images/test.jpg";
-            when(awsConfig.getS3Client()).thenReturn(s3Client);
-            when(awsConfig.getS3BucketName()).thenReturn("test-bucket");
+            MultipartFile file = createMockImage("group.png", "image/png", new byte[]{1, 2, 3, 4});
+            setupMockForUpload();
 
             // When
-            s3Service.deleteImage(key);
+            GroupImageUrl result = s3Service.uploadGroupImage(file);
 
             // Then
-            verify(s3Client).deleteObject(any(DeleteObjectRequest.class));
+            assertThat(result.toString())
+                    .startsWith("https://test-bucket.s3.")
+                    .contains(groupDirectory)
+                    .endsWith(".png");
+            verify(s3Client).putObject(any(PutObjectRequest.class), any(RequestBody.class));
         }
+
+        @Test
+        @DisplayName("이미지 업로드 - 잘못된 확장자")
+        void uploadGroupImage_invalidExtension() {
+            // Given
+            MultipartFile file = createMockImage("invalid.txt", "text/plain", new byte[]{1, 2, 3, 4});
+
+            // When & Then
+            assertThatThrownBy(() -> s3Service.uploadGroupImage(file))
+                    .isInstanceOf(S3UploadException.class)
+                    .hasMessageContaining(S3UploadErrorCode.INVALID_EXTENSION.getMessage());
+        }
+
+        @Test
+        @DisplayName("이미지 업로드 - 파일 크기 초과")
+        void uploadGroupImage_fileSizeExceedsLimit() {
+            // Given
+            MultipartFile file = createMockImage("large.jpg", "image/jpeg", new byte[3 * 1024 * 1024]);
+            when(awsConfig.getMaxFileSize()).thenReturn(2L * 1024 * 1024);
+
+            // When & Then
+            assertThatThrownBy(() -> s3Service.uploadGroupImage(file))
+                    .isInstanceOf(S3UploadException.class)
+                    .hasMessageContaining(S3UploadErrorCode.FILE_SIZE_EXCEEDED.getMessage());
+        }
+    }
+
+    private MultipartFile createMockImage(String fileName, String contentType, byte[] content) {
+        return new MockMultipartFile("image", fileName, contentType, content);
+    }
+
+    private void setupMockForUpload() {
+        when(awsConfig.getS3Client()).thenReturn(s3Client);
+        when(awsConfig.getS3BucketName()).thenReturn("test-bucket");
+        when(awsConfig.getMaxFileSize()).thenReturn(1024L * 1024 * 2);
+        when(awsConfig.getRegion()).thenReturn(software.amazon.awssdk.regions.Region.of("ap-northeast-2"));
     }
 }

--- a/src/test/java/org/noostak/server/infra/S3ServiceTest.java
+++ b/src/test/java/org/noostak/server/infra/S3ServiceTest.java
@@ -26,12 +26,11 @@ class S3ServiceTest {
     private final S3Client s3Client = mock(S3Client.class);
 
     private final S3Service s3Service = new S3Service(awsConfig);
+    private final String bucketName = "test-bucket";
 
     @Nested
     @DisplayName("프로필 이미지 업로드 테스트")
     class UploadProfileImageTests {
-
-        private final String bucketName = "test-bucket";
         private final String profileDirectory = "profile/";
 
         @Test
@@ -81,8 +80,6 @@ class S3ServiceTest {
     @Nested
     @DisplayName("그룹 이미지 업로드 테스트")
     class UploadGroupImageTests {
-
-        private final String bucketName = "test-bucket";
         private final String groupDirectory = "group/";
 
         @Test
@@ -135,7 +132,7 @@ class S3ServiceTest {
 
     private void setupMockForUpload() {
         when(awsConfig.getS3Client()).thenReturn(s3Client);
-        when(awsConfig.getS3BucketName()).thenReturn("test-bucket");
+        when(awsConfig.getS3BucketName()).thenReturn(bucketName);
         when(awsConfig.getMaxFileSize()).thenReturn(1024L * 1024 * 2);
         when(awsConfig.getRegion()).thenReturn(software.amazon.awssdk.regions.Region.of("ap-northeast-2"));
     }


### PR DESCRIPTION
# 🚀 What’s this PR about?
- **작업 내용 요약:** 
   - S3에 업로드된 이미지의 URL을 반환하는 로직을 추가합니다. 이를 통해 Member와 Group 엔티티에서 각각 프로필 이미지와 그룹 이미지를 관리할 수 있도록 합니다.
- **핵심 변경사항:** 중요한 변경 사항이나 핵심 로직을 간단히 정리해 주세요.
   - S3에 업로드 한 파일의 URL을 반환하는 서비스 로직 추가
   - group과 profile 이미지 업로드에 대한 경로 분리(`/group`, `/profile`)


# 🛠️ What’s been done?
- 주요 변경사항을 상세히 기술하세요. (예: 새로운 기능 추가, 버그 수정, 코드 리팩토링 등)
  - uploadProfileImage : /profile/ 디렉토리에 업로드 및 ProfileImageUrl 반환.
  - uploadGroupImage: /group/ 디렉토리에 업로드 및 GroupImageUrl 반환

# 🧪 Testing Details
- **테스트 코드 및 결과:** 작성한 테스트 코드와 주요 테스트 케이스를 설명하고, 통과된 테스트 결과를 요약해 주세요.
  - 단위테스트 통과
  - 통합테스트 통과

# 👀 Checkpoints for Reviewers
- **리뷰 시 확인할 사항:** 
  - 작성된 테스트 코드의 시나리오가 충분한지, 추가적인 검증이 필요한지 확인
  - ProfileImageUrl과 GroupImageUrl이 실제 Member 및 Group 엔티티에서 어떻게 활용될지
     - `ProfileImageUrl profileImageUrl = s3Service.uploadProfileImage(profileImageFile);` 이렇게 S3에 이미지 업로드 및 URL 반환 기능을 사용하고, `profileImageUrl`를 활용해서 다른 로직을 구현한 다음 `return memberRepository.save(member);` DB에 저장할 때 URL을 함께 저장하도록 하면 될 것 같습니다.

# 📚 References & Resources
- x

# 🎯 Related Issues
- closes : #63 
