### PR TITLE
[♻️refactor] S3 이미지 반환 메서드 기능 분리

### DIFF
--- a/src/main/java/org/noostak/server/infra/FileStorageService.java
+++ b/src/main/java/org/noostak/server/infra/FileStorageService.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 
 public interface FileStorageService {
     String uploadImage(String directoryPath, MultipartFile file) throws IOException;
+    String getImageUrl(String key);
 
     void deleteImage(String key) throws IOException;
 }

--- a/src/main/java/org/noostak/server/infra/ImageHandlerService.java
+++ b/src/main/java/org/noostak/server/infra/ImageHandlerService.java
@@ -1,0 +1,26 @@
+package org.noostak.server.infra;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class ImageHandlerService {
+
+    private final FileStorageService fileStorageService;
+
+    public String uploadImage(String directoryPath, MultipartFile image) throws IOException {
+        return fileStorageService.uploadImage(directoryPath, image);
+    }
+
+    public void deleteImage(String key) throws IOException {
+        fileStorageService.deleteImage(key);
+    }
+
+    public String getImageUrl(String key) {
+        return fileStorageService.getImageUrl(key);
+    }
+}

--- a/src/main/java/org/noostak/server/infra/S3Service.java
+++ b/src/main/java/org/noostak/server/infra/S3Service.java
@@ -2,10 +2,8 @@ package org.noostak.server.infra;
 
 import lombok.RequiredArgsConstructor;
 import org.noostak.server.global.config.AwsConfig;
-import org.noostak.server.group.domain.vo.GroupImageUrl;
 import org.noostak.server.infra.error.S3ErrorCode;
 import org.noostak.server.infra.error.S3Exception;
-import org.noostak.server.member.domain.vo.ProfileImageUrl;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -41,7 +39,14 @@ public class S3Service implements FileStorageService {
 
         s3Client.putObject(request, RequestBody.fromBytes(image.getBytes()));
 
-        return generateFileUrl(key);
+        return key;
+    }
+
+    public String generateFileUrl(String key) {
+        return String.format("https://%s.s3.%s.amazonaws.com/%s",
+                awsConfig.getS3BucketName(),
+                awsConfig.getRegion().id(),
+                key);
     }
 
     @Override
@@ -60,26 +65,9 @@ public class S3Service implements FileStorageService {
         }
     }
 
-    public ProfileImageUrl uploadProfileImage(MultipartFile file) throws IOException {
-        String url = uploadImage("/profile/", file);
-        return ProfileImageUrl.from(url);
-    }
-
-    public GroupImageUrl uploadGroupImage(MultipartFile file) throws IOException {
-        String url = uploadImage("/group/", file);
-        return GroupImageUrl.from(url);
-    }
-
     private String generateFileName(String originalFilename) {
         String extension = originalFilename.substring(originalFilename.lastIndexOf("."));
         return UUID.randomUUID() + extension;
-    }
-
-    private String generateFileUrl(String key) {
-        return String.format("https://%s.s3.%s.amazonaws.com/%s",
-                awsConfig.getS3BucketName(),
-                awsConfig.getRegion().id(),
-                key);
     }
 
     private void validateFile(MultipartFile file) {

--- a/src/main/java/org/noostak/server/infra/error/S3ErrorCode.java
+++ b/src/main/java/org/noostak/server/infra/error/S3ErrorCode.java
@@ -9,7 +9,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum S3ErrorCode implements ErrorCode {
     INVALID_EXTENSION(HttpStatus.BAD_REQUEST, "이미지 확장자는 jpg, png, webp만 가능합니다."),
-    FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "이미지 사이즈는 5MB를 넘을 수 없습니다."),
+    FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "이미지 사이즈는 2MB를 넘을 수 없습니다."),
     OBJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "삭제하려는 이미지를 찾을 수 없습니다.");
 
     public static final String PREFIX = "[S3 ERROR] ";

--- a/src/test/java/org/noostak/server/infra/ImageHandlerServiceTest.java
+++ b/src/test/java/org/noostak/server/infra/ImageHandlerServiceTest.java
@@ -1,0 +1,57 @@
+package org.noostak.server.infra;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.multipart.MultipartFile;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+class ImageHandlerServiceTest {
+
+    private ImageHandlerService imageHandlerService;
+    private MockFileStorageService mockFileStorageService;
+
+    @BeforeEach
+    void setUp() {
+        mockFileStorageService = new MockFileStorageService();
+        imageHandlerService = new ImageHandlerService(mockFileStorageService);
+    }
+
+    @Test
+    void testUploadImage() throws Exception {
+        // given
+        String directoryPath = "/profile-images/";
+        MultipartFile mockImage = mock(MultipartFile.class);
+
+        // when
+        String actualUrl = imageHandlerService.uploadImage(directoryPath, mockImage);
+
+        // then
+        assertEquals("https://mock-url.com/test-image.png", actualUrl);
+    }
+
+    @Test
+    void testGetImageUrl() {
+
+        // given
+        String key = "test-key";
+
+        // when
+        String actualUrl = imageHandlerService.getImageUrl(key);
+
+        // then
+        assertEquals("http://mocked-url/" + key, actualUrl);
+    }
+
+    @Test
+    void testDeleteImage() throws Exception {
+
+        // given
+        String key = "test-key";
+
+        // when
+        imageHandlerService.deleteImage(key);
+
+    }
+}

--- a/src/test/java/org/noostak/server/infra/MockFileStorageService.java
+++ b/src/test/java/org/noostak/server/infra/MockFileStorageService.java
@@ -10,6 +10,12 @@ public class MockFileStorageService implements FileStorageService {
     }
 
     @Override
+    public String getImageUrl(String key) {
+        return "http://mocked-url/" + key;
+    }
+
+
+    @Override
     public void deleteImage(String key) {
     }
 }

--- a/src/test/java/org/noostak/server/infra/S3ServiceTest.java
+++ b/src/test/java/org/noostak/server/infra/S3ServiceTest.java
@@ -38,7 +38,6 @@ class S3ServiceTest {
             MultipartFile file = createMockImage("profile.jpg", "image/jpeg", new byte[]{1, 2, 3, 4});
             String directoryPath = "profile/";
 
-            // Mocking AWS S3 interactions
             setupMockForUpload();
 
             // When
@@ -68,7 +67,7 @@ class S3ServiceTest {
         void uploadImage_fileSizeExceedsLimit() {
             // Given
             MultipartFile file = createMockImage("large.jpg", "image/jpeg", new byte[3 * 1024 * 1024]);
-            when(awsConfig.getMaxFileSize()).thenReturn(2L * 1024 * 1024); // Set max file size to 2MB
+            when(awsConfig.getMaxFileSize()).thenReturn(2L * 1024 * 1024);
 
             // When & Then
             assertThatThrownBy(() -> s3Service.uploadImage("profile/", file))
@@ -89,7 +88,7 @@ class S3ServiceTest {
             String key = "profile/abc123.jpg";
 
             // When
-            String fileUrl = s3Service.generateFileUrl(key);
+            String fileUrl = s3Service.getImageUrl(key);
 
             // Then
             assertThat(fileUrl).startsWith("https://")

--- a/src/test/java/org/noostak/server/infra/S3ServiceTest.java
+++ b/src/test/java/org/noostak/server/infra/S3ServiceTest.java
@@ -6,14 +6,12 @@ import org.junit.jupiter.api.Test;
 import org.noostak.server.global.config.AwsConfig;
 import org.noostak.server.infra.error.S3ErrorCode;
 import org.noostak.server.infra.error.S3Exception;
-import org.noostak.server.member.domain.vo.ProfileImageUrl;
-import org.noostak.server.group.domain.vo.GroupImageUrl;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 
 import java.io.IOException;
 
@@ -30,100 +28,74 @@ class S3ServiceTest {
     private final String bucketName = "test-bucket";
 
     @Nested
-    @DisplayName("프로필 이미지 업로드 테스트")
-    class UploadProfileImageTests {
-        private final String profileDirectory = "profile/";
+    @DisplayName("파일 업로드 테스트")
+    class UploadImageTests {
 
         @Test
         @DisplayName("이미지 업로드 - 성공")
-        void uploadProfileImage_success() throws IOException {
+        void uploadImage_success() throws IOException {
             // Given
             MultipartFile file = createMockImage("profile.jpg", "image/jpeg", new byte[]{1, 2, 3, 4});
+            String directoryPath = "profile/";
+
+            // Mocking AWS S3 interactions
             setupMockForUpload();
 
             // When
-            ProfileImageUrl result = s3Service.uploadProfileImage(file);
+            String key = s3Service.uploadImage(directoryPath, file);
 
             // Then
-            assertThat(result.toString())
-                    .startsWith("https://test-bucket.s3.")
-                    .contains(profileDirectory)
+            assertThat(key).startsWith(directoryPath)
                     .endsWith(".jpg");
+
             verify(s3Client).putObject(any(PutObjectRequest.class), any(RequestBody.class));
         }
 
         @Test
         @DisplayName("이미지 업로드 - 잘못된 확장자")
-        void uploadProfileImage_invalidExtension() {
+        void uploadImage_invalidExtension() {
             // Given
             MultipartFile file = createMockImage("invalid.txt", "text/plain", new byte[]{1, 2, 3, 4});
 
             // When & Then
-            assertThatThrownBy(() -> s3Service.uploadProfileImage(file))
+            assertThatThrownBy(() -> s3Service.uploadImage("profile/", file))
                     .isInstanceOf(S3Exception.class)
                     .hasMessageContaining(S3ErrorCode.INVALID_EXTENSION.getMessage());
         }
 
         @Test
         @DisplayName("이미지 업로드 - 파일 크기 초과")
-        void uploadProfileImage_fileSizeExceedsLimit() {
+        void uploadImage_fileSizeExceedsLimit() {
             // Given
             MultipartFile file = createMockImage("large.jpg", "image/jpeg", new byte[3 * 1024 * 1024]);
-            when(awsConfig.getMaxFileSize()).thenReturn(2L * 1024 * 1024);
+            when(awsConfig.getMaxFileSize()).thenReturn(2L * 1024 * 1024); // Set max file size to 2MB
 
             // When & Then
-            assertThatThrownBy(() -> s3Service.uploadProfileImage(file))
+            assertThatThrownBy(() -> s3Service.uploadImage("profile/", file))
                     .isInstanceOf(S3Exception.class)
                     .hasMessageContaining(S3ErrorCode.FILE_SIZE_EXCEEDED.getMessage());
         }
     }
 
     @Nested
-    @DisplayName("그룹 이미지 업로드 테스트")
-    class UploadGroupImageTests {
-        private final String groupDirectory = "group/";
+    @DisplayName("URL 생성 테스트")
+    class GenerateFileUrlTests {
 
         @Test
-        @DisplayName("이미지 업로드 - 성공")
-        void uploadGroupImage_success() throws IOException {
+        @DisplayName("URL 생성 - 성공")
+        void generateFileUrl_success() {
             // Given
-            MultipartFile file = createMockImage("group.png", "image/png", new byte[]{1, 2, 3, 4});
             setupMockForUpload();
+            String key = "profile/abc123.jpg";
 
             // When
-            GroupImageUrl result = s3Service.uploadGroupImage(file);
+            String fileUrl = s3Service.generateFileUrl(key);
 
             // Then
-            assertThat(result.toString())
-                    .startsWith("https://test-bucket.s3.")
-                    .contains(groupDirectory)
-                    .endsWith(".png");
-            verify(s3Client).putObject(any(PutObjectRequest.class), any(RequestBody.class));
-        }
-
-        @Test
-        @DisplayName("이미지 업로드 - 잘못된 확장자")
-        void uploadGroupImage_invalidExtension() {
-            // Given
-            MultipartFile file = createMockImage("invalid.txt", "text/plain", new byte[]{1, 2, 3, 4});
-
-            // When & Then
-            assertThatThrownBy(() -> s3Service.uploadGroupImage(file))
-                    .isInstanceOf(S3Exception.class)
-                    .hasMessageContaining(S3ErrorCode.INVALID_EXTENSION.getMessage());
-        }
-
-        @Test
-        @DisplayName("이미지 업로드 - 파일 크기 초과")
-        void uploadGroupImage_fileSizeExceedsLimit() {
-            // Given
-            MultipartFile file = createMockImage("large.jpg", "image/jpeg", new byte[3 * 1024 * 1024]);
-            when(awsConfig.getMaxFileSize()).thenReturn(2L * 1024 * 1024);
-
-            // When & Then
-            assertThatThrownBy(() -> s3Service.uploadGroupImage(file))
-                    .isInstanceOf(S3Exception.class)
-                    .hasMessageContaining(S3ErrorCode.FILE_SIZE_EXCEEDED.getMessage());
+            assertThat(fileUrl).startsWith("https://")
+                    .contains("test-bucket")
+                    .contains("profile")
+                    .endsWith(".jpg");
         }
     }
 
@@ -167,7 +139,6 @@ class S3ServiceTest {
                     .hasMessageContaining(S3ErrorCode.OBJECT_NOT_FOUND.getMessage());
         }
     }
-
 
     private MultipartFile createMockImage(String fileName, String contentType, byte[] content) {
         return new MockMultipartFile("image", fileName, contentType, content);


### PR DESCRIPTION
# 🚀 What’s this PR about?
- **작업 내용 요약:** S3 이미지 반환 메서드와 URL 생성 메서드를 분리했습니다.
- **핵심 변경사항:** 
   - `uploadImage` 메서드는 파일을 S3에 업로드한 후, 생성된 키만 반환하도록 수정했습니다.
   - S3 키를 기반으로 URL을 생성하는 메서드 `generateFileUrl`을 분리했습니다.
   - 이를 통해 클라이언트가 파일 업로드와 URL 생성 요청을 독립적으로 사용할 수 있도록 개선했습니다.

# 🛠️ What’s been done?
- 주요 변경사항을 상세히 기술하세요. 
   - 파일 업로드 및 키 반환: `uploadImage` 메서드가 S3에 파일을 업로드하고, 해당 키를 반환.
   - URL 생성 요청: `generateFileUrl` 메서드가 제공된 키를 기반으로 S3 URL을 반환.

# 🧪 Testing Details
- **테스트 코드 및 결과:** 
  - 단위테스트를 수정하고
  - 통합테스트를 실행했습니다.

# 👀 Checkpoints for Reviewers
- **리뷰 시 확인할 사항:** 
  - 우선 연관된 기능인데 자꾸 수정사항을 만들어 영향을 드린 점 죄송합니다.
  - 현재의 수정사항은 클라이언트에서 이미 S3에 이미지를 업로드 하고난 후의 요청인 경우 해당 이미지의 key를 가지고 있다는 전제하에 수정했으며, 혹시 클라이언트가 키 값을 모를 때를 고려한 별도의 키 관리 시스템이 필요하다면 추가하겠습니다.
  - 위의 사항과 연관되어, key값을 따로 저장 및 관리해줄 필요가 있을지에 대해서 고민을 했는데, 도메인 관련 코드를 건드려야 한다는 점에서 고민을 하다가 구현하지 않았는데, 이 부분 필요하다고 생각하시는 경우에 의견 남겨주시면 구현하겠습니다.

   - 추가적으로 uploadProfileImage와 uploadGroupImage 메서드는 각각의 path를 구분하기 쉽게 하고자 하는 생각에서 작성했었지만, 불필요한 메서드라는 점에서 코드 리팩토링 과정에서 삭제했습니다.


# 🎯 Related Issues
- #70 